### PR TITLE
register redux store change history in chrome devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-redux": "^6.0.1",
     "react-scripts": "2.1.8",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "socket.io-client": "^2.2.0",
     "typescript": "3.3.3333"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,19 @@ import './index.scss';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
 import { reducers } from './reducers/index';
 
-const store = createStore(reducers);
+const state = {};
+
+const store = createStore(
+  reducers,
+  state,
+  composeWithDevTools(
+    applyMiddleware()
+  )
+);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8795,6 +8795,11 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
 redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"


### PR DESCRIPTION
Minor tweak.

[The TypeScript instructions](https://github.com/zalmoxisus/redux-devtools-extension#11-basic-store) calls for importing type definitions from `redux-devtools-extension`, hence the new dependency.

Alternatively, I could've written the store configuration in its own file, away from [index.tsx](https://github.com/CraigBeswetherick/Typescript-phaser3-react-redux-boilerplate/blob/master/src/index.tsx) ([here's an example](https://github.com/notrab/create-react-app-redux/blob/master/src/store.js)), but that's totally up to the developer.